### PR TITLE
tags delete in order

### DIFF
--- a/rareapi/views/tag_view.py
+++ b/rareapi/views/tag_view.py
@@ -27,8 +27,7 @@ class TagView(ViewSet):
         Returns:
             Response -- JSON serialized list of tags
         """
-        tags = Tag.objects.all()
-        
+        tags = Tag.objects.all().order_by('label')
         serializer = TagSerializer(tags, many=True)
         return Response(serializer.data)
     
@@ -45,6 +44,11 @@ class TagView(ViewSet):
         serializer = TagSerializer(tag)
         return Response(serializer.data)
     
+    def destroy(self, request, pk):
+        tag = Tag.objects.get(pk=pk)
+        tag.delete()
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+        
 class TagSerializer(serializers.ModelSerializer):
     """JSON serializer for Tags"""
     class Meta:

--- a/sqlscratch.sql
+++ b/sqlscratch.sql
@@ -3,7 +3,7 @@ DELETE FROM rareapi_comment;
 
 UPDATE auth_user
 SET is_staff = 1
-WHERE id = 2
+WHERE id = 1
 
 INSERT INTO rareapi_admin 
 ('id', 'user_id', 'avatar')


### PR DESCRIPTION
tags list now shows buttons for admin and admin can delete tags



Fixes # 13/18

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] pull code, start server
- [ ] navigate to tags manager
- [ ] see tags listed with edit/delete buttons (if you are signed in as an admin)
- [ ] delete tag- make sure it's the right tag that is deleted

