### PR TITLE
tags can be edited now

### DIFF
--- a/rareapi/views/tag_view.py
+++ b/rareapi/views/tag_view.py
@@ -43,6 +43,17 @@ class TagView(ViewSet):
         
         serializer = TagSerializer(tag)
         return Response(serializer.data)
+    def update(self, request, pk):
+        """Handle PUT requests for a game
+
+        Returns:
+            Response -- Empty body with 204 status code
+        """
+        tag = Tag.objects.get(pk=pk)
+        serializer = TagSerializer(tag, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
     
     def destroy(self, request, pk):
         tag = Tag.objects.get(pk=pk)


### PR DESCRIPTION
tags can now be edited by admins



Fixes # 19

## Type of change

Please delete options that are not relevant.


- New feature (non-breaking change which adds functionality)


- [ ] pull code, start server
- [ ] click on tags manager
- [ ] click on edit tag
- [ ] edit tag and send in edit
- [ ] user should be pushed back to tags list with updated tag
- [ ] if user pushed cancel in tag edit, they should be pushed back to the list as well

