### PR TITLE
users view now comes back with is active property

### DIFF
--- a/rareapi/views/user_view.py
+++ b/rareapi/views/user_view.py
@@ -14,11 +14,32 @@ class UserView(ViewSet):
         
         serializer = UserSerializer(user)
         return Response(serializer.data)
+    
+    def retrieve(self, request, pk=None):
 
+        try:
+            user = User.objects.get(pk=pk)
+            serializer = UserSerializer(user, context={'request': request})
+            return Response(serializer.data)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+        
+    def update(self, request, pk):
+        """Handle PUT requests for a user
+
+        Returns:
+            Response -- Empty body with 204 status code
+        """
+        user = User.objects.get(pk=pk)
+        serializer = UserSerializer(user, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+    
 class UserSerializer(serializers.ModelSerializer):
     """JSON serializer for reviews"""
     class Meta:
         model = User
-        fields = ('id', 'is_staff', 'username')
+        fields = ('id', 'is_staff', 'username', 'is_active')
         depth = 1
         


### PR DESCRIPTION
Admin can now approve or disable users from user list


Fixes # 28

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?


- [ ] pull and run code
- [ ] as an admin, navigate to users in nav bar
- [ ] see checkboxes for approving/disabling users
- [ ] click on some and have fun
- [ ] see the network making the changes to is_active attribute

